### PR TITLE
Refactor ISO639_2 imports

### DIFF
--- a/pymkv/ISO639_2.py
+++ b/pymkv/ISO639_2.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import iso639
-from iso639 import LanguageNotFoundError
+from iso639 import Language, LanguageNotFoundError
 
 
 def is_iso639_2(language: str) -> bool:
@@ -17,7 +16,7 @@ def is_iso639_2(language: str) -> bool:
         True if the language code is valid according to ISO 639-2, False otherwise.
     """
     try:
-        iso639.Language.from_part2b(language)
+        Language.from_part2b(language)
         return True  # noqa: TRY300
     except LanguageNotFoundError:
         return False


### PR DESCRIPTION
Replace separate iso639 imports with a single import statement. This change simplifies the import structure and improves code readability by directly importing required classes from the iso639 module.