### PR TITLE
Update `prepare_mkvtoolnix_path` to handle existing paths

### DIFF
--- a/pymkv/utils.py
+++ b/pymkv/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import shlex
 from functools import wraps
+from pathlib import Path
 from typing import Any, Callable
 
 
@@ -16,17 +17,18 @@ def prepare_mkvtoolnix_path(path: str | list[str] | os.PathLike | tuple[str, ...
     Returns
     -------
     tuple[str, ...]
-        The prepared path as a list of strings.
+        The prepared path as a tuple of strings.
 
     Raises
     ------
     ValueError
-        If the path type is invalid. Expected str, list of str, or os.PathLike.
+        If the path type is invalid. Expected str, list of str, tuple of str, or os.PathLike.
     """
     if isinstance(path, os.PathLike):
         return (os.fspath(path),)
     elif isinstance(path, str):  # noqa: RET505
-        return tuple(shlex.split(path))
+        # Check if the path exists and is accessible
+        return (path,) if Path(path).exists() else tuple(shlex.split(path))
     elif isinstance(path, list):
         return tuple(path)
     elif isinstance(path, tuple):

--- a/tests/test_utils_prepare_mkvtoolnix_path.py
+++ b/tests/test_utils_prepare_mkvtoolnix_path.py
@@ -1,5 +1,5 @@
-import os
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -16,13 +16,35 @@ def test_prepare_mkvmerge_path_with_base_string() -> None:
     assert result == ("mkvmerge",)
 
 
+@patch("pathlib.Path.exists")
+def test_prepare_mkvmerge_path_with_linux_path(mock_exists):  # noqa: ANN201, ANN001
+    mock_exists.return_value = True
+    path = "/home/bob/dir with space/mkv/mkvmerge"
+    result = utils.prepare_mkvtoolnix_path(path)
+    assert result == (path,)
+
+
+@patch("pathlib.Path.exists")
+def test_prepare_mkvmerge_path_with_windows_path(mock_exists):  # noqa: ANN201, ANN001
+    mock_exists.return_value = True
+    path = r"C:\Program Files\MKVToolNix\mkvmerge.exe"
+    result = utils.prepare_mkvtoolnix_path(path)
+    assert result == (path,)
+
+
+def test_prepare_mkvmerge_path_with_nonexistent_path() -> None:
+    path = "/nonexistent/path with spaces/mkvmerge"
+    result = utils.prepare_mkvtoolnix_path(path)
+    assert result == ("/nonexistent/path", "with", "spaces/mkvmerge")
+
+
 def test_prepare_mkvmerge_path_with_list() -> None:
     result = utils.prepare_mkvtoolnix_path(["mkvmerge", "path"])
     assert result == ("mkvmerge", "path")
 
 
 def test_prepare_mkvmerge_path_with_pathlike() -> None:
-    path = Path(os.path.join(os.path.dirname(__file__), "mkvmerge"))  # noqa: PTH120, PTH118
+    path = Path(__file__).parent / "mkvmerge"
     result = utils.prepare_mkvtoolnix_path(path)
     assert result == (str(path),)
 


### PR DESCRIPTION
Enhanced `prepare_mkvtoolnix_path` to check if a string path exists and return it directly if it does. Added corresponding unit tests to ensure proper handling of existing Linux and Windows paths, as well as paths that do not exist.