### PR TITLE
Simplify GitHub workflows triggering events

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,9 +6,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
   workflow_dispatch:
 permissions:
     contents: write

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -3,8 +3,6 @@ name: Upload Python Package
 on:
   release:
     types: [created]
-  pull_request:
-  push:
 
 jobs:
   deploy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-on: [push, pull_request]
+on: [push]
 
 permissions:
   contents: read


### PR DESCRIPTION
Updated `tests.yml` to trigger only on push events, removing the pull_request event. Similarly, revised `docs.yml` to eliminate pull_request triggers and maintain push and workflow_dispatch events. This cleanup aims to streamline CI/CD pipeline triggers for better performance and clarity.