### PR TITLE
Add test for setting invalid BCP47 language tag and removing the BCP47 check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
 
   # Run the Ruff linter.
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.3
+    rev: v0.7.4
     hooks:
       # Linter
       - id: ruff

--- a/pymkv/BCP47.py
+++ b/pymkv/BCP47.py
@@ -1,6 +1,9 @@
+from functools import cache
+
 import bcp47
 
 
+@cache
 def is_bcp47(language_ietf: str) -> bool:
     """
     Check if a given language tag is a valid BCP 47 language tag.

--- a/pymkv/MKVTrack.py
+++ b/pymkv/MKVTrack.py
@@ -44,7 +44,6 @@ import subprocess as sp
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from pymkv.BCP47 import is_bcp47
 from pymkv.ISO639_2 import is_iso639_2
 from pymkv.utils import ensure_info, prepare_mkvtoolnix_path
 from pymkv.Verifications import checking_file_path, get_file_info, verify_supported
@@ -391,15 +390,8 @@ class MKVTrack:
 
         Args:
             language_ietf (str): The language to set in BCP47 format.
-
-        Raises:
-            ValueError: If the passed in language is not a BCP47 language code.
         """
-        if language_ietf is None or is_bcp47(language_ietf):
-            self._language_ietf = language_ietf
-        else:
-            msg = "not a BCP47 language code"
-            raise ValueError(msg)
+        self._language_ietf = language_ietf
 
     @property
     def tags(self) -> str | None:

--- a/tests/test_actions_track.py
+++ b/tests/test_actions_track.py
@@ -196,3 +196,15 @@ def test_get_track_error(get_path_test_file: Path) -> None:
     mkv = MKVFile(get_path_test_file)
     with pytest.raises(IndexError):
         mkv.get_track(2)
+
+
+def test_added_lang_in_track_and_mux_file(
+    get_base_path: Path,
+    get_path_test_file: Path,
+) -> None:
+    mkv = MKVFile(get_path_test_file)
+    output_file = get_base_path / "file-test.mkv"
+    track = cast(MKVTrack, mkv.get_track(1))
+    track.language_ietf = "TEST"
+    with pytest.raises(ValueError):  # noqa: PT011
+        mkv.mux(output_file)


### PR DESCRIPTION
Introduce a test to verify error handling when setting an invalid BCP47 language tag for a track and attempting to mux the file. Also, improve performance by caching the BCP47 validity check.