### PR TITLE
Deprecate `is_bcp47` function

### DIFF
--- a/pymkv/BCP47.py
+++ b/pymkv/BCP47.py
@@ -1,3 +1,4 @@
+import warnings
 from functools import cache
 
 import bcp47
@@ -18,6 +19,11 @@ def is_bcp47(language_ietf: str) -> bool:
     bool
         True if the language tag is a valid BCP 47 language tag, False otherwise.
     """
+    warnings.warn(
+        "The function 'is_bcp47' is deprecated and will be removed in a future release.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
     if language_ietf != "und":
         return language_ietf in bcp47.languages.values()
     else:  # noqa: RET505


### PR DESCRIPTION
Warn users that the `is_bcp47` function is deprecated and will be removed in a future release. Added a DeprecationWarning to inform users of this upcoming change.