### PR TITLE
Add test for MKV creation and streamline MKVTrack behavior

### DIFF
--- a/pymkv/MKVTrack.py
+++ b/pymkv/MKVTrack.py
@@ -45,7 +45,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from pymkv.ISO639_2 import is_iso639_2
-from pymkv.utils import ensure_info, prepare_mkvtoolnix_path
+from pymkv.utils import prepare_mkvtoolnix_path
 from pymkv.Verifications import checking_file_path, get_file_info, verify_supported
 
 if TYPE_CHECKING:
@@ -140,7 +140,7 @@ class MKVTrack:
 
         # base
         self.mkvmerge_path = prepare_mkvtoolnix_path(mkvmerge_path)
-        self._info_json: dict[str, Any] = existing_info or {}
+        self._info_json: dict[str, Any] | None = existing_info or None
         self._file_path: str
         self.file_path = file_path
         self._track_id: int
@@ -264,12 +264,6 @@ class MKVTrack:
         return self._track_id
 
     @track_id.setter
-    @ensure_info(
-        "_info_json",
-        get_file_info,
-        ["file_path", "mkvmerge_path"],
-        check_path=False,
-    )
     def track_id(self, track_id: int) -> None:
         """
         Set the ID of the track within the file.
@@ -283,6 +277,8 @@ class MKVTrack:
         Raises:
             IndexError: If the passed in index is out of range of the file's tracks.
         """
+        if not self._info_json:
+            self._info_json = get_file_info(self.file_path, mkvmerge_path=self.mkvmerge_path)
         tracks = self._info_json.get("tracks", [])
         if not 0 <= track_id < len(tracks):
             msg = "track index out of range"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import random
 from collections.abc import Generator
 from pathlib import Path
 
@@ -26,7 +27,7 @@ def _cleanup_mkv_files(
     get_path_test_file_two: Path,
 ) -> Generator[None, None, None]:
     yield
-    for ext in ["*.mkv", "*.mp4", "*.ogg", "*.txt"]:
+    for ext in ["*.mkv", "*.mp4", "*.ogg", "*.txt", "*.srt"]:
         for file_path in get_base_path.glob(ext):
             if file_path not in (get_path_test_file, get_path_test_file_two):
                 file_path.unlink()
@@ -37,3 +38,32 @@ def temp_file(tmp_path: Path) -> str:
     file = tmp_path / "test_attachment.txt"
     file.write_text("Test content")
     return str(file)
+
+
+def generate_random_text() -> str:
+    """Generates random text for subtitles."""
+    words = ["hello", "world", "test", "subtitle", "example", "random", "generate", "python"]
+    return " ".join(random.choices(words, k=random.randint(3, 8)))  # noqa: S311
+
+
+def create_srt_file_with_random_text(path: Path, subtitles_count: int = 5) -> None:
+    """Creates an SRT file with randomly generated text."""
+    with Path.open(path, "w", encoding="utf-8") as file:
+        for i in range(1, subtitles_count + 1):
+            start = f"00:00:{i:02},000"  # Generate start time
+            end = f"00:00:{i+1:02},000"  # Generate end time
+            text = generate_random_text()  # Generate random subtitle text
+            file.write(f"{i}\n{start} --> {end}\n{text}\n\n")
+
+
+@pytest.fixture
+def get_path_test_srt(get_base_path: Path) -> Path:
+    """
+    Fixture to create a path for a temporary SRT file.
+
+    Uses the `get_base_path` fixture to determine the directory and
+    generates a random SRT file.
+    """
+    srt_path = get_base_path / "test_file.srt"
+    create_srt_file_with_random_text(srt_path)
+    return srt_path

--- a/tests/test_create_mkv.py
+++ b/tests/test_create_mkv.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from pymkv import MKVFile, MKVTrack
+
+
+def test_create_new_mkv(
+    get_base_path: Path,
+    get_path_test_file: Path,
+    get_path_test_srt: Path,
+) -> None:
+    output_file = get_base_path / "new-file.mkv"
+    mkv = MKVFile(str(get_path_test_file))
+    track = MKVTrack(str(get_path_test_srt))
+
+    mkv.add_track(track)
+
+    assert len(mkv.tracks) == 3  # noqa: PLR2004
+    mkv.mux(output_file)


### PR DESCRIPTION
Introduce a new unit test `test_create_new_mkv` for validating MKV file creation with a subtitle track. Update the `MKVTrack` class to safely handle track ID setting by directly ensuring `_info_json` availability, and adjust file cleanup utility to handle SRT files in tests.