### PR TITLE
Add test for adding file while ignoring warnings

### DIFF
--- a/tests/test_add_file.py
+++ b/tests/test_add_file.py
@@ -35,3 +35,13 @@ def test_add_file_error(get_base_path: Path, get_path_test_file: Path) -> None:
 
     with pytest.raises(ValueError):  # noqa: PT011
         mkv.mux(output_file)
+
+
+def test_add_file_and_ignore_warning(get_base_path: Path, get_path_test_file: Path) -> None:
+    output_file = get_base_path / "file-test.mkv"
+    mkv = MKVFile(get_path_test_file)
+
+    mkv_two = MKVFile(get_path_test_file)
+    mkv.add_file(mkv_two)
+
+    mkv.mux(output_file, ignore_warning=True)


### PR DESCRIPTION
This commit introduces a test to verify the functionality of adding a file and ignoring warnings during the muxing process. It ensures that the `ignore_warning=True` parameter works as expected when calling the `mux` method on an MKVFile object. This enhances test coverage by addressing a potential edge case in file handling.