### PR TITLE
Update workflows and pre-commit hooks for Python 3.13 and linting

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,18 +16,13 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-      - name: Set up python
-        id: setup-python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
       - name: Install uv
         id: setup-uv
         uses: astral-sh/setup-uv@v5
         with:
           version: latest
-          python-version: ${{ matrix.python-version }}
-          cache-suffix:  ${{ matrix.python-version }}
+          python-version: "3.13"
+          enable-cache: true
       - name: Install project
         run: uv sync --all-extras --dev
       - name: Sphinx build

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -19,17 +19,13 @@ jobs:
           echo "tag=$tag" >> $GITHUB_OUTPUT
     - run: |
         echo "tag=${{ steps.vars.outputs.tag }}"
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
     - name: Install uv
       id: setup-uv
       uses: astral-sh/setup-uv@v5
       with:
         version: latest
-        python-version: ${{ matrix.python-version }}
-        cache-suffix:  ${{ matrix.python-version }}
+        python-version: "3.13"
+        enable-cache: true
     - name: Install project
       run: uv sync --all-extras --dev
     - name: Validate Release Version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,18 +53,13 @@ jobs:
       - name: Verify MKVToolNix installation (Linux and macOS)
         if: matrix.os != 'windows-latest'
         run: mkvmerge -V
-      - name: Set up Python
-        id: setup-python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         id: setup-uv
         uses: astral-sh/setup-uv@v5
         with:
           version: latest
           python-version: ${{ matrix.python-version }}
-          cache-suffix:  ${{ matrix.python-version }}
+          enable-cache: true
       - name: Install project
         run: uv sync --all-extras --dev
       - name: Run tests and collect coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,15 +21,14 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: '0.6.3'
+    rev: '0.6.9'
     hooks:
       - id: uv-lock
-      - id: uv-export
       - id: uv-sync
 
   # Run the Ruff linter.
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.9
+    rev: v0.11.2
     hooks:
       # Linter
       - id: ruff


### PR DESCRIPTION
Switch to Python 3.13 in workflows and enable caching for uv setup to optimize runtime. Upgrade pre-commit hooks to newer versions for improved functionality and compatibility. Remove redundant steps like `uv-export` and unnecessary Python setup in workflows.