### PR TITLE
Refactor/iso639 2 getter

### DIFF
--- a/pymkv/ISO639_2.py
+++ b/pymkv/ISO639_2.py
@@ -13,9 +13,12 @@ None
 
 from __future__ import annotations
 
-from iso639.language import Language, LanguageNotFoundError
+from functools import cache
+
+from iso639 import Language, LanguageNotFoundError
 
 
+@cache
 def get_iso639_2(language: str) -> str | None:
     """
     Get the ISO 639-2 code for a given language.
@@ -35,6 +38,6 @@ def get_iso639_2(language: str) -> str | None:
         return None
 
     try:
-        return Language.match(language).part2b
+        return Language.match(language, strict_case=False).part2b
     except LanguageNotFoundError:
         return None

--- a/pymkv/ISO639_2.py
+++ b/pymkv/ISO639_2.py
@@ -1,34 +1,40 @@
-"""Utilities for checking ISO 639-2 language code compliance.
+"""Utilities for working with ISO 639-2 language codes.
 
 Examples
 --------
->>> from pymkv.ISO639_2 import is_iso639_2  # doctest: +SKIP
->>> is_iso639_2('eng')  # doctest: +SKIP
-True
+>>> from pymkv.ISO639_2 import get_iso639_2  # doctest: +SKIP
+>>> get_iso639_2("eng")  # doctest: +SKIP
+'eng'
+>>> get_iso639_2("English")  # doctest: +SKIP
+'eng'
+>>> get_iso639_2("xyz")  # doctest: +SKIP
+None
 """
 
 from __future__ import annotations
 
-from iso639 import Language, LanguageNotFoundError
+from iso639.language import Language, LanguageNotFoundError
 
 
-def is_iso639_2(language: str) -> bool:
+def get_iso639_2(language: str) -> str | None:
     """
+    Get the ISO 639-2 code for a given language.
+
     Parameters
     ----------
     language : str
-        The language code to check for ISO 639-2 compatibility.
+        The language code or name to check for ISO 639-2 compatibility.
 
     Returns
     -------
-    bool
-        True if the language code is valid according to ISO 639-2, False otherwise.
+    str | None
+        The ISO 639-2 (bibliographic) code if the language is recognized,
+        None otherwise.
     """
     if not isinstance(language, str):
-        return False
+        return None
 
     try:
-        Language.from_part2b(language)
-        return True  # noqa: TRY300
+        return Language.match(language).part2b
     except LanguageNotFoundError:
-        return False
+        return None

--- a/pymkv/MKVFile.py
+++ b/pymkv/MKVFile.py
@@ -281,7 +281,7 @@ class MKVFile:
         if language is not None:
             iso_code = get_iso639_2(language)
             if iso_code is None:
-                msg = "not a valid ISO 639-2 language"
+                msg = f"'{language}' cannot be mapped to a valid ISO 639-2 language code"
                 raise ValueError(msg)
             self._chapter_language = iso_code
         else:
@@ -1260,7 +1260,7 @@ class MKVFile:
         file_path : str
             The chapters file to be added to the :class:`~pymkv.MKVFile` object.
         language : str, optional
-            Must be an ISO639-2 language code. Only applied if no existing language information exists in chapters.
+             Only applied if no existing language information exists in chapters.
 
         Raises
         ------

--- a/pymkv/MKVFile.py
+++ b/pymkv/MKVFile.py
@@ -85,7 +85,7 @@ from pymkv.command_generators import (
     TrackOptions,
     TrackOrderOptions,
 )
-from pymkv.ISO639_2 import is_iso639_2
+from pymkv.ISO639_2 import get_iso639_2
 from pymkv.MKVAttachment import MKVAttachment
 from pymkv.MKVTrack import MKVTrack
 from pymkv.models import MkvMergeOutput, TrackProperties
@@ -271,15 +271,21 @@ class MKVFile:
         Set the language code of the chapters in the MKVFile object.
 
         Args:
-            language (str): The language code for the chapters. Must be a valid ISO 639-2 language code.
+            language (str | None): The language code or name for the chapters.
+                Must be a valid ISO 639-2 language code or recognized language name,
+                or None to unset.
 
         Raises:
-            ValueError: If the provided language code is not a valid ISO 639-2 language code.
+            ValueError: If the provided language code or name is not recognized as a valid ISO 639-2 code.
         """
-        if language is not None and not is_iso639_2(language):
-            msg = "The provided language code is not a valid ISO 639-2 language code."
-            raise ValueError(msg)
-        self._chapter_language = language
+        if language is not None:
+            iso_code = get_iso639_2(language)
+            if iso_code is None:
+                msg = "not a valid ISO 639-2 language"
+                raise ValueError(msg)
+            self._chapter_language = iso_code
+        else:
+            self._chapter_language = None
 
     @property
     def global_tag_entries(self) -> int:

--- a/pymkv/MKVTrack.py
+++ b/pymkv/MKVTrack.py
@@ -361,7 +361,7 @@ class MKVTrack:
         if language is not None:
             iso_code = get_iso639_2(language)
             if iso_code is None:
-                msg = "cannot be mapped to a valid ISO 639-2 code."
+                msg = f"'{language}' cannot be mapped to a valid ISO 639-2 language code"
                 raise ValueError(msg)
             self._language = iso_code
         else:

--- a/pymkv/MKVTrack.py
+++ b/pymkv/MKVTrack.py
@@ -52,7 +52,7 @@ from typing import TYPE_CHECKING, Any
 
 import msgspec
 
-from pymkv.ISO639_2 import is_iso639_2
+from pymkv.ISO639_2 import get_iso639_2
 from pymkv.models import MkvMergeOutput
 from pymkv.TypeTrack import get_track_extension
 from pymkv.utils import prepare_mkvtoolnix_path
@@ -351,16 +351,21 @@ class MKVTrack:
         Set the language of the MKVTrack.
 
         Args:
-            language (str): The language to be set for the MKVTrack.
+            language (str | None): The language code or name to be set for the MKVTrack.
+                Must be a valid ISO 639-2 code or recognized language name,
+                or None to unset.
 
         Raises:
-            ValueError: If the provided language is not a valid ISO639-2 language code.
+            ValueError: If the provided language code or name cannot be mapped to a valid ISO 639-2 code.
         """
-        if language is None or is_iso639_2(language):
-            self._language = language
+        if language is not None:
+            iso_code = get_iso639_2(language)
+            if iso_code is None:
+                msg = "cannot be mapped to a valid ISO 639-2 code."
+                raise ValueError(msg)
+            self._language = iso_code
         else:
-            msg = "not an ISO639-2 language code"
-            raise ValueError(msg)
+            self._language = None
 
     @property
     def pts(self) -> int:

--- a/tests/test_iso639_2.py
+++ b/tests/test_iso639_2.py
@@ -1,19 +1,25 @@
 from typing import cast
 
-from pymkv.ISO639_2 import is_iso639_2
+from pymkv.ISO639_2 import get_iso639_2
 
 
-def test_is_iso639_2_true() -> None:
-    assert is_iso639_2("eng") is True
+def test_get_iso639_2_valid_code() -> None:
+    assert get_iso639_2("eng") == "eng"
 
 
-def test_is_iso639_2_false() -> None:
-    assert is_iso639_2("xyz") is False
+def test_get_iso639_2_valid_name() -> None:
+    # Using language name instead of code
+    assert get_iso639_2("English") == "eng"
 
 
-def test_is_iso639_2_non_str_input() -> None:
-    assert is_iso639_2(cast("str", 123)) is False
+def test_get_iso639_2_invalid_code() -> None:
+    assert get_iso639_2("xyz") is None
 
 
-def test_is_iso639_2_empty_string() -> None:
-    assert is_iso639_2("") is False
+def test_get_iso639_2_non_str_input() -> None:
+    # Should gracefully return None for non-str input
+    assert get_iso639_2(cast("str", 123)) is None
+
+
+def test_get_iso639_2_empty_string() -> None:
+    assert get_iso639_2("") is None

--- a/tests/test_mkv_chapters_tags.py
+++ b/tests/test_mkv_chapters_tags.py
@@ -13,10 +13,13 @@ def test_chapter_language_getter_setter() -> None:
     mkv.chapter_language = "eng"
     assert mkv.chapter_language == "eng"
 
+    mkv.chapter_language = "English"
+    assert mkv.chapter_language == "eng"
+
     mkv.chapter_language = None
     assert mkv.chapter_language is None
 
-    with pytest.raises(ValueError, match="not a valid ISO 639-2 language code"):
+    with pytest.raises(ValueError, match="not a valid ISO 639-2 language"):
         mkv.chapter_language = "invalid_code"
 
 

--- a/tests/test_mkv_chapters_tags.py
+++ b/tests/test_mkv_chapters_tags.py
@@ -19,7 +19,7 @@ def test_chapter_language_getter_setter() -> None:
     mkv.chapter_language = None
     assert mkv.chapter_language is None
 
-    with pytest.raises(ValueError, match="not a valid ISO 639-2 language"):
+    with pytest.raises(ValueError, match="'invalid_code' cannot be mapped to a valid ISO 639-2 language code"):
         mkv.chapter_language = "invalid_code"
 
 

--- a/tests/test_mkvtrack_language.py
+++ b/tests/test_mkvtrack_language.py
@@ -1,0 +1,30 @@
+import pytest
+
+from pymkv import MKVTrack
+
+
+def test_language_name_to_code(get_path_test_file: str):
+    track = MKVTrack(get_path_test_file)
+    track.language = "English"
+    assert track.language == "eng"
+
+    track.language = "fra"
+    assert track.language == "fre"
+
+    track.language = "deu"
+    assert track.language == "ger"
+
+    # language case insensitive
+    track.language = "english"  # lowercase
+    assert track.language == "eng"
+
+    track.language = "ARAbIC"
+    assert track.language == "ara"
+
+    with pytest.raises(ValueError) as exc:
+        track.language = "invalid-lang"
+    assert "cannot be mapped to a valid ISO 639-2 language code" in str(exc.value)
+
+    # unset language
+    track.language = None
+    assert track.language is None

--- a/tests/test_mkvtrack_language.py
+++ b/tests/test_mkvtrack_language.py
@@ -3,7 +3,7 @@ import pytest
 from pymkv import MKVTrack
 
 
-def test_language_name_to_code(get_path_test_file: str):
+def test_language_name_to_code(get_path_test_file: str) -> None:
     track = MKVTrack(get_path_test_file)
     track.language = "English"
     assert track.language == "eng"
@@ -21,9 +21,11 @@ def test_language_name_to_code(get_path_test_file: str):
     track.language = "ARAbIC"
     assert track.language == "ara"
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(
+        ValueError,
+        match="cannot be mapped to a valid ISO 639-2 language code",
+    ):
         track.language = "invalid-lang"
-    assert "cannot be mapped to a valid ISO 639-2 language code" in str(exc.value)
 
     # unset language
     track.language = None


### PR DESCRIPTION
This pull request refactors the ISO639-2 handling in the project to allow language values to be provided in any valid code or language name format. The input is automatically converted to the canonical ISO 639-2 code for consistent storage.