### PR TITLE
Fix pytest version specifier in uv.lock

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -804,7 +804,7 @@ requires-dist = [
 dev = [
     { name = "mypy", specifier = ">=1.14.1,<2.0.0" },
     { name = "pyinstrument", specifier = ">=5.1.2" },
-    { name = "pytest", specifier = ">=8.3.4,<9.0.0" },
+    { name = "pytest", specifier = ">=8.3.4,<10.0.0" },
     { name = "pytest-cov", specifier = ">=6.0.0,<8.0.0" },
     { name = "pytest-mypy", specifier = ">=0.10.3,<2.0.0" },
     { name = "pytest-ruff", specifier = ">=0.4.1,<1.0.0" },


### PR DESCRIPTION
## Summary

- Updates the pytest version upper bound in `uv.lock` from `<9.0.0` to `<10.0.0` to match the specifier in `pyproject.toml`.
- Fixes a mismatch detected by the `uv-lock` pre-commit hook.