### PR TITLE
fix: conditional Self import depending on python version

### DIFF
--- a/pymkv/MKVFile.py
+++ b/pymkv/MKVFile.py
@@ -60,6 +60,7 @@ import logging
 import os
 import re
 import subprocess as sp
+import sys
 import tempfile
 from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
@@ -67,7 +68,11 @@ from typing import Any, TypeVar, cast
 
 import bitmath
 import msgspec
-from typing_extensions import Self
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 from pymkv.chapters import (
     ChapterAtom,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "bitmath<3.0.0,>=2.0.0",
     "python-iso639<2027.0.0,>=2026.4.20",
     "msgspec>=0.21.0",
+    "typing-extensions>=4.15.0 ; python_full_version < '3.11'",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -767,6 +767,7 @@ dependencies = [
     { name = "bitmath" },
     { name = "msgspec" },
     { name = "python-iso639" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 
 [package.dev-dependencies]
@@ -788,6 +789,7 @@ requires-dist = [
     { name = "bitmath", specifier = ">=2.0.0,<3.0.0" },
     { name = "msgspec", specifier = ">=0.21.0" },
     { name = "python-iso639", specifier = ">=2026.4.20,<2027.0.0" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.15.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Description

Fixes #110

## Notes

Tested for:

- Python 3.10:
  ```sh
  uv run --no-dev --python 3.10 python -c "import pymkv"
  ```
- Python 3.11:
  ```sh
  uv run --no-dev --python 3.11 python -c "import pymkv"
  ```

I don't think we can implement actual tests because `typing-extension` is always present in dev runtimes.
Could use dedicated tools though, like [deptry](https://deptry.com/).
