### PR TITLE
ci: add runtime-only import smoke test

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -90,3 +90,23 @@ jobs:
         if: success() || failure() # always run even if the previous step fails
         with:
           report_paths: './test-results/junit.xml'
+
+  runtime-import:
+    name: Runtime-only import smoke test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: latest
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+
+      - name: Import pymkv without dev dependencies
+        run: uv run --no-dev python -c "import pymkv"


### PR DESCRIPTION
## Summary
- Adds a `runtime-import` CI job that runs `uv run --no-dev python -c "import pymkv"` across Python 3.10–3.14 on Linux.
- Catches the class of regression seen in #110: a runtime import of a package that's only present transitively via the dev dependency group.

## Notes
Depends on #111 — until that PR is merged this job will fail on master, which is the expected behavior (the test is a real reproducer for the bug).

## Test plan
- [ ] CI green after #111 is merged and this branch is rebased.
- [ ] Confirm the job fails on the pre-fix `master` SHA (it does locally: `uv run --no-dev --isolated python -c "import pymkv"` → `ModuleNotFoundError: No module named 'typing_extensions'`).