### PR TITLE
chore: release 2.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pymkv2"
-version = "2.3.0"
+version = "2.3.1"
 description = "A Python wrapper for mkvmerge. It provides support for muxing, splitting, linking, chapters, tags, and attachments through the use of mkvmerge."
 authors = [
     {name = "GitBib", email = "job@bnff.website"},

--- a/uv.lock
+++ b/uv.lock
@@ -761,7 +761,7 @@ wheels = [
 
 [[package]]
 name = "pymkv2"
-version = "2.3.0"
+version = "2.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "bitmath" },


### PR DESCRIPTION
## Summary
- Bumps version to 2.3.1.

Patch release picking up the post-2.3.0 fixes:
- #111 — declare `typing-extensions` as a runtime dependency on Python < 3.11 and use stdlib `typing.Self` on 3.11+ (fixes the `ModuleNotFoundError` on `import pymkv` for runtime-only installs).
- #112 — CI smoke job that imports the package without dev dependencies, to catch this class of regression in the future.

## Test plan
- [ ] CI green on master matrix.
- [ ] Runtime-only import smoke job passes.