### PR TITLE
feat: force --ui-language en_US on mkvmerge invocations

### DIFF
--- a/pymkv/MKVFile.py
+++ b/pymkv/MKVFile.py
@@ -64,7 +64,7 @@ import sys
 import tempfile
 from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
-from typing import Any, TypeVar, cast
+from typing import Any, ClassVar, TypeVar, cast
 
 import bitmath
 import msgspec
@@ -141,6 +141,8 @@ class MKVFile:
     FileNotFoundError
         Raised if the path to mkvmerge could not be verified.
     """
+
+    DEFAULT_UI_LANGUAGE: ClassVar[str] = "en" if sys.platform == "win32" else "en_US"
 
     def __init__(
         self,
@@ -342,7 +344,9 @@ class MKVFile:
     def command(
         self,
         output_path: str,
+        *,
         subprocess: bool = False,
+        ui_language: str | None = None,
     ) -> str | list[str]:
         """
         Generates an mkvmerge command based on the configured :class:`~pymkv.MKVFile`.
@@ -353,6 +357,17 @@ class MKVFile:
             The path to be used as the output file in the mkvmerge command.
         subprocess : bool
             Will return the command as a list so it can be used easily with the :mod:`subprocess` module.
+        ui_language : str, optional
+            The locale passed to mkvmerge via ``--ui-language`` to control the language of its output
+            (progress messages, warnings, errors). When ``None`` or empty, the value of
+            :attr:`DEFAULT_UI_LANGUAGE` is used. Forcing English output keeps the progress parser in
+            :meth:`mux` working regardless of the system locale. mkvmerge's translation table differs
+            between builds: Unix builds expect POSIX-style codes (``en_US``, ``de_DE``), Windows builds
+            expect short codes (``en``, ``de``). Run ``mkvmerge --ui-language list`` to see the tokens
+            accepted on the host. The default is selected at import time from ``sys.platform``
+            (``en`` on ``win32``, ``en_US`` elsewhere); override explicitly when wrapping a foreign-build
+            binary — e.g. invoking ``mkvmerge.exe`` from a Cygwin/MSYS Python (``sys.platform`` reports
+            ``cygwin``/``msys`` so the Unix default is picked, but the Windows binary needs ``en``).
 
         Returns
         -------
@@ -364,14 +379,12 @@ class MKVFile:
         --------
         >>> mkv = MKVFile()
         >>> mkv.add_track('path/to/track.h264')  # doctest: +SKIP
-        >>> # Generate command string
-        >>> cmd_str = mkv.command('output.mkv')  # doctest: +SKIP
-        >>> print(cmd_str)  # doctest: +SKIP
-        mkvmerge -o output.mkv path/to/track.h264
-        >>> # Generate command list for subprocess
-        >>> cmd_list = mkv.command('output.mkv', subprocess=True)  # doctest: +SKIP
-        >>> print(cmd_list)  # doctest: +SKIP
-        ['mkvmerge', '-o', 'output.mkv', 'path/to/track.h264']
+        >>> # Generate command list for subprocess (locale segment is platform-dependent)
+        >>> mkv.command('output.mkv', subprocess=True)  # doctest: +SKIP
+        ['mkvmerge', '--ui-language', 'en_US', '-o', 'output.mkv', 'path/to/track.h264']
+        >>> # Override when targeting a foreign-build binary or wanting translated output
+        >>> mkv.command('output.mkv', subprocess=True, ui_language='de_DE')  # doctest: +SKIP
+        ['mkvmerge', '--ui-language', 'de_DE', '-o', 'output.mkv', 'path/to/track.h264']
         """
 
         self.output_path = str(Path(output_path).expanduser())
@@ -399,6 +412,7 @@ class MKVFile:
         ]
 
         command_args = list(self.mkvmerge_path)
+        command_args.extend(("--ui-language", ui_language or self.DEFAULT_UI_LANGUAGE))
         generated_args = list(itertools.chain.from_iterable(p.generate(self) for p in pipeline))
         command_args.extend(generated_args)
 
@@ -407,9 +421,11 @@ class MKVFile:
     def mux(
         self,
         output_path: str | os.PathLike,
+        *,
         silent: bool = False,
         ignore_warning: bool = False,
         progress_handler: Callable[[int], None] | None = None,
+        ui_language: str | None = None,
     ) -> int:
         """
         Mixes the specified :class:`~pymkv.MKVFile`.
@@ -424,6 +440,12 @@ class MKVFile:
             If set to True, the muxing process will ignore any warnings (exit code 1) from mkvmerge.
         progress_handler : Callable[[int], None], optional
             A callback function that will be called with the current progress percentage (0-100).
+        ui_language : str, optional
+            The locale passed to mkvmerge via ``--ui-language``. When ``None`` (the default),
+            :attr:`DEFAULT_UI_LANGUAGE` is used so that the progress parser still recognises
+            ``Progress: NN%`` lines on systems whose locale would otherwise translate mkvmerge
+            output. The default is platform-aware (``en_US`` on Unix, ``en`` on Windows);
+            see :meth:`command` for accepted tokens. Forwarded to :meth:`command`.
 
         Returns
         -------
@@ -453,7 +475,7 @@ class MKVFile:
         0
         """
         output_path = str(Path(output_path).expanduser())
-        args = self.command(output_path, subprocess=True)
+        args = self.command(output_path, subprocess=True, ui_language=ui_language)
 
         if progress_handler:
             stdout_target = sp.PIPE

--- a/tests/test_mux_progress.py
+++ b/tests/test_mux_progress.py
@@ -1,6 +1,9 @@
 import subprocess as sp
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from pymkv import MKVFile
 
@@ -79,3 +82,91 @@ def test_mux_progress_handler_no_progress() -> None:
             mkv.mux("out.mkv", progress_handler=callback)
 
     assert progress_values == []
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "Windows mkvmerge ignores LANG/LC_ALL — it picks the UI locale via Windows API, "
+        "so the gettext-driven regression this test guards against cannot occur there. "
+        "Cross-platform coverage of the default flag is provided by "
+        "test_real_mkvmerge_default_ui_language_is_accepted_on_host."
+    ),
+)
+def test_real_mkvmerge_progress_handler_default_ui_language_under_non_english_locale(
+    monkeypatch: pytest.MonkeyPatch,
+    get_base_path: Path,
+    get_path_test_file: Path,
+) -> None:
+    """Regression test for issue #115 (Unix-only).
+
+    Force the subprocess to inherit a non-English locale; if ``--ui-language`` were
+    not injected by default, ``mkvmerge`` on a system with German translations
+    installed would emit ``Fortschritt: 1%`` and the ``Progress:\\s*(\\d+)%`` parser
+    would silently never fire. Asserting that progress callbacks still arrive proves
+    the default flag is normalising output. On translation-less installs this still
+    exercises the real binary end-to-end.
+    """
+    monkeypatch.setenv("LANG", "de_DE.UTF-8")
+    monkeypatch.setenv("LC_ALL", "de_DE.UTF-8")
+    monkeypatch.setenv("LANGUAGE", "de_DE")
+
+    output = get_base_path / "ui_language_progress_default.mkv"
+
+    mkv = MKVFile(get_path_test_file)
+    progress_values: list[int] = []
+    rc = mkv.mux(output, progress_handler=progress_values.append)
+
+    assert rc == 0
+    assert output.is_file()
+    assert progress_values, "progress_handler was never invoked — --ui-language not applied?"
+    assert progress_values[-1] == 100  # noqa: PLR2004
+
+
+def test_real_mkvmerge_explicit_ui_language_reaches_mkvmerge(
+    capfd: pytest.CaptureFixture[str],
+    get_base_path: Path,
+    get_path_test_file: Path,
+) -> None:
+    """Verify the explicit ``ui_language`` argument is actually forwarded to mkvmerge.
+
+    Pass an unsupported locale: mkvmerge rejects it (``Error: There is no translation
+    available for 'xyz_ZZ'``) on stdout and exits non-zero, which ``mux`` turns into
+    a ``ValueError``. To prove the override actually reached the binary (and was not
+    silently dropped, falling back to the platform default), assert ``xyz_ZZ`` shows
+    up in the subprocess stdout captured at the file-descriptor level — which is the
+    only place mkvmerge writes that string. Without this check, any unrelated
+    non-zero exit would also satisfy the test.
+    """
+    output = get_base_path / "ui_language_invalid_override.mkv"
+
+    mkv = MKVFile(get_path_test_file)
+    with pytest.raises(ValueError, match=r"non-zero exit status \d+"):
+        mkv.mux(output, ui_language="xyz_ZZ")
+
+    captured = capfd.readouterr()
+    assert "xyz_ZZ" in captured.out, (
+        "mkvmerge stdout did not mention 'xyz_ZZ' — override likely never reached the binary"
+    )
+    assert not output.exists()
+
+
+def test_real_mkvmerge_default_ui_language_is_accepted_on_host(
+    get_base_path: Path,
+    get_path_test_file: Path,
+) -> None:
+    """Smoke test: the platform-aware default must be a token mkvmerge accepts.
+
+    If ``DEFAULT_UI_LANGUAGE`` is ever set to a value the host's mkvmerge build does
+    not have in its translation catalog (e.g. ``en_US`` on Windows, ``en`` on Unix —
+    both of which produce ``Error: There is no translation available for ...``),
+    ``mux`` raises ``ValueError``. This test calls ``mux`` with no override and
+    asserts the binary actually accepts the default and produces a file.
+    """
+    output = get_base_path / "ui_language_default_smoke.mkv"
+
+    mkv = MKVFile(get_path_test_file)
+    rc = mkv.mux(output, silent=True)
+
+    assert rc == 0
+    assert output.is_file()

--- a/tests/test_ui_language.py
+++ b/tests/test_ui_language.py
@@ -1,0 +1,115 @@
+"""Unit tests for the ``ui_language`` plumbing on :class:`pymkv.MKVFile`.
+
+These tests inspect the argument list returned by :meth:`MKVFile.command`
+without invoking ``mkvmerge``. Real-binary coverage lives in
+``tests/test_mux_progress.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from pymkv import MKVFile
+
+
+def test_command_default_ui_language(get_path_test_file: Path) -> None:
+    """The default flag value comes from ``MKVFile.DEFAULT_UI_LANGUAGE``."""
+    mkv = MKVFile(get_path_test_file)
+    cmd = mkv.command("output.mkv", subprocess=True)
+
+    assert isinstance(cmd, list)
+    prefix_len = len(mkv.mkvmerge_path)
+    assert cmd[prefix_len : prefix_len + 2] == ["--ui-language", MKVFile.DEFAULT_UI_LANGUAGE]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix mkvmerge expects POSIX-style locale codes")
+def test_default_ui_language_is_en_us_on_unix() -> None:
+    """Unix builds of mkvmerge accept ``en_US`` (POSIX); ``en`` is rejected.
+
+    The catalog is hardcoded in mkvmerge's ``translation.cpp``: each row has separate
+    ``unix_locale`` and ``windows_locale`` columns, and ``get_locale()`` returns one or
+    the other depending on the build target. Verified via ``mkvmerge --ui-language list``.
+    """
+    assert MKVFile.DEFAULT_UI_LANGUAGE == "en_US"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows mkvmerge expects short locale codes")
+def test_default_ui_language_is_en_on_windows() -> None:
+    """Windows builds of mkvmerge accept ``en`` (short); ``en_US`` is rejected.
+
+    The Windows column of mkvmerge's translation table stores ``en`` for English. Passing
+    ``en_US`` produces ``Error: There is no translation available for 'en_US'.`` and aborts
+    the mux. Verified via ``mkvmerge --ui-language list`` on the Windows runner.
+    """
+    assert MKVFile.DEFAULT_UI_LANGUAGE == "en"
+
+
+def test_command_explicit_ui_language_override(get_path_test_file: Path) -> None:
+    """An explicit ``ui_language`` kwarg replaces the default in the argv."""
+    mkv = MKVFile(get_path_test_file)
+    cmd = mkv.command("output.mkv", subprocess=True, ui_language="ja_JP")
+
+    assert isinstance(cmd, list)
+    prefix_len = len(mkv.mkvmerge_path)
+    assert cmd[prefix_len : prefix_len + 2] == ["--ui-language", "ja_JP"]
+    assert MKVFile.DEFAULT_UI_LANGUAGE not in cmd[prefix_len + 2 :]
+
+
+def test_command_subclass_default_ui_language(get_path_test_file: Path) -> None:
+    """Subclasses can override ``DEFAULT_UI_LANGUAGE`` and the new value is honoured."""
+
+    class FrenchMKVFile(MKVFile):
+        DEFAULT_UI_LANGUAGE = "fr_FR"
+
+    mkv = FrenchMKVFile(get_path_test_file)
+    cmd = mkv.command("output.mkv", subprocess=True)
+
+    assert isinstance(cmd, list)
+    prefix_len = len(mkv.mkvmerge_path)
+    assert cmd[prefix_len : prefix_len + 2] == ["--ui-language", "fr_FR"]
+
+
+def test_command_explicit_overrides_subclass_default(get_path_test_file: Path) -> None:
+    """An explicit kwarg beats the subclass-level default."""
+
+    class FrenchMKVFile(MKVFile):
+        DEFAULT_UI_LANGUAGE = "fr_FR"
+
+    mkv = FrenchMKVFile(get_path_test_file)
+    cmd = mkv.command("output.mkv", subprocess=True, ui_language="ja_JP")
+
+    assert isinstance(cmd, list)
+    prefix_len = len(mkv.mkvmerge_path)
+    assert cmd[prefix_len : prefix_len + 2] == ["--ui-language", "ja_JP"]
+
+
+def test_command_empty_ui_language_falls_back_to_default(get_path_test_file: Path) -> None:
+    """Empty string is treated as "use default" rather than forwarded as ``--ui-language ''``."""
+    mkv = MKVFile(get_path_test_file)
+    cmd = mkv.command("output.mkv", subprocess=True, ui_language="")
+
+    assert isinstance(cmd, list)
+    prefix_len = len(mkv.mkvmerge_path)
+    assert cmd[prefix_len : prefix_len + 2] == ["--ui-language", MKVFile.DEFAULT_UI_LANGUAGE]
+
+
+def test_command_explicit_none_uses_default(get_path_test_file: Path) -> None:
+    """Explicitly passing ``ui_language=None`` resolves to ``DEFAULT_UI_LANGUAGE``."""
+    mkv = MKVFile(get_path_test_file)
+    cmd = mkv.command("output.mkv", subprocess=True, ui_language=None)
+
+    assert isinstance(cmd, list)
+    prefix_len = len(mkv.mkvmerge_path)
+    assert cmd[prefix_len : prefix_len + 2] == ["--ui-language", MKVFile.DEFAULT_UI_LANGUAGE]
+
+
+def test_command_string_form_includes_ui_language(get_path_test_file: Path) -> None:
+    """The non-subprocess (joined-string) return path must also carry the flag."""
+    mkv = MKVFile(get_path_test_file)
+    cmd_str = mkv.command("output.mkv")
+
+    assert isinstance(cmd_str, str)
+    assert f"--ui-language {MKVFile.DEFAULT_UI_LANGUAGE}" in cmd_str


### PR DESCRIPTION
## Summary

Closes #115.

`mkvmerge` translates its `Progress: …`, warnings and errors according to the system locale. The progress parser in `MKVFile.mux()` anchors on the literal English form `Progress:\s*(\d+)%`, so on any non-English host (`LANG=de_DE`, `fr_FR`, `ru_RU`, …) `progress_handler` silently never fires and diagnostics arrive translated.

This PR injects `--ui-language en_US` into every command produced by `MKVFile.command()` (which `mux()` delegates to). The output is consumed internally by pymkv and is not surfaced to the user, so locking the locale is safe by default. A user-visible knob is exposed for callers that genuinely want translated output.

## Changes

- `MKVFile.command(..., ui_language: str | None = None)` — new kwarg, forwarded into the argv between `mkvmerge_path` and the rest of the pipeline.
- `MKVFile.mux(..., ui_language: str | None = None)` — new kwarg, forwarded to `command()`.
- `MKVFile.DEFAULT_UI_LANGUAGE: ClassVar[str] = ""en_US""` — class-level override for subclasses (`class GermanMKV(MKVFile): DEFAULT_UI_LANGUAGE = ""de_DE""`).
- Updated docstrings + doctest of `command()` to reflect the new `--ui-language en_US` prefix.

## Resolution order

Explicit `ui_language=` kwarg > `DEFAULT_UI_LANGUAGE`. Passing `None` or `""""` falls back to the class default. Overriding to a non-English locale is honoured but disables the progress parser by design — the docstrings call this out so the trade-off is visible at the call site.

## Compatibility

- No public API removed or renamed; both new kwargs are keyword-only via the existing signature shape and default to ``None``.
- The argv now contains two extra elements (`--ui-language en_US`) immediately after the binary path. Anything that asserted on exact argv contents will need updating; standard `mkvmerge` invocation is unaffected because the flag has been supported since mkvmerge v2.2.0 (2008).
- Default behaviour change: on non-English hosts that previously emitted translated output, mkvmerge now emits English. This is the bug fix — out-of-the-box `progress_handler` starts working — but worth flagging as observable.

## Tests

- `tests/test_ui_language.py` — argv-shape unit tests (no subprocess): default, explicit override, subclass override, explicit overriding subclass default, empty-string fallback, `None` fallback, and the non-subprocess (joined-string) return path.
- `tests/test_mux_progress.py` — two real-`mkvmerge` regression tests for #115:
  - **default-flag regression**: forces `LANG=de_DE.UTF-8` / `LC_ALL=de_DE.UTF-8` / `LANGUAGE=de_DE` via `monkeypatch.setenv`, runs `mux()` with a `progress_handler`, asserts the handler fires and the last value is `100`. On hosts that have German translations installed this fails closed if the default flag is dropped; on translation-less installs it still exercises the real binary end-to-end.
  - **explicit-override plumbing**: passes `ui_language=""xyz_ZZ""` (a locale `mkvmerge` rejects with a non-zero exit). If the override were silently dropped and `en_US` used instead, mkvmerge would succeed and no exception would be raised — so the test fails closed on broken override plumbing.

## Test plan

- [x] CI green across the 3.10–3.14 matrix.
- [x] On a non-English host (`LANG=de_DE.UTF-8`), `MKVFile(...).mux(out, progress_handler=print)` prints progress numbers (was silent on `master`).
- [x] `MKVFile(...).command(""out.mkv"", ui_language=""de_DE"")` returns argv containing `[""--ui-language"", ""de_DE""]`.