### PR TITLE
chore: release 2.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pymkv2"
-version = "2.3.1"
+version = "2.3.2"
 description = "A Python wrapper for mkvmerge. It provides support for muxing, splitting, linking, chapters, tags, and attachments through the use of mkvmerge."
 authors = [
     {name = "GitBib", email = "job@bnff.website"},

--- a/uv.lock
+++ b/uv.lock
@@ -761,7 +761,7 @@ wheels = [
 
 [[package]]
 name = "pymkv2"
-version = "2.3.1"
+version = "2.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "bitmath" },


### PR DESCRIPTION
## Summary
- Bumps version to 2.3.2.

Patch release picking up the post-2.3.1 fix:
- #116 — force `--ui-language` (platform-aware: `en_US` on Unix, `en` on Windows)
  on every `mkvmerge` invocation produced by `MKVFile.command()` / `MKVFile.mux()`,
  so the `Progress: NN%` parser keeps working regardless of the host locale
  (fixes #115). Adds `ui_language` kwarg + `MKVFile.DEFAULT_UI_LANGUAGE` ClassVar
  for explicit overrides; existing kwargs on `command()` and `mux()` are now
  keyword-only.

CI tooling bumps included via dependabot:
- #114 — `j178/prek-action` 2.0.2 → 2.0.3.