### PR TITLE
fix: pull test fixtures from pymkv-files repo and fail loudly on bad downloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,39 +1,41 @@
-FILE_URL := https://pymkv-files.bnff.website/file.mkv
-FILE_TWO_URL := https://pymkv-files.bnff.website/file_2.mkv
+FILES_BASE_URL := https://raw.githubusercontent.com/GitBib/pymkv-files/master
+FILE_URL := $(FILES_BASE_URL)/file.mkv
+FILE_TWO_URL := $(FILES_BASE_URL)/file_2.mkv
 
 TEST_FILE := tests/file.mkv
 TEST_TWO_FILE := tests/file_2.mkv
 
 TEST_DIR := tests/
 
+# --fail makes curl exit non-zero on HTTP errors instead of writing the error
+# body into the target file, which would leave a corrupt "MKV" behind.
+CURL := curl -sSL --fail --retry 3 --retry-delay 2
+
 .PHONY: test clean
 
 test: $(TEST_FILE) $(TEST_TWO_FILE)
 	@echo "Running mkvmerge -V..."
 	@mkvmerge -V
-	@echo "Running mkvmerge -J $(TEST_FILE)..."
-	@mkvmerge -J $(TEST_FILE)
-	@echo "Running mkvmerge -J $(TEST_TWO_FILE)..."
-	@mkvmerge -J $(TEST_TWO_FILE)
+	@echo "Verifying test files..."
+	@for f in $(TEST_FILE) $(TEST_TWO_FILE); do \
+		mkvmerge -J $$f | grep -q '"recognized"[[:space:]]*:[[:space:]]*true' \
+			|| { echo "ERROR: $$f is not a valid Matroska file. Run 'make clean' and retry."; exit 1; }; \
+	done
 	uv run pytest --cov=pymkv $(TEST_DIR) --cov-report=xml --junitxml=test-results/junit.xml
 
+# Download to a .part file and rename only on success, so an interrupted
+# download never leaves a partial file that make would treat as up to date.
 $(TEST_FILE):
-	@if [ ! -f $(TEST_FILE) ]; then \
-		echo "Downloading $(TEST_FILE)..."; \
-		curl -sSL $(FILE_URL) -o $(TEST_FILE); \
-		echo "Downloaded to $$(realpath $(TEST_FILE))"; \
-	else \
-		echo "$(TEST_FILE) already exists. Skipping download."; \
-	fi
+	@echo "Downloading $(TEST_FILE)..."
+	@$(CURL) $(FILE_URL) -o $(TEST_FILE).part
+	@mv $(TEST_FILE).part $(TEST_FILE)
+	@echo "Downloaded $(TEST_FILE)"
 
 $(TEST_TWO_FILE):
-	@if [ ! -f $(TEST_TWO_FILE) ]; then \
-		echo "Downloading $(TEST_TWO_FILE)..."; \
-		curl -sSL $(FILE_TWO_URL) -o $(TEST_TWO_FILE); \
-		echo "Downloaded to $$(realpath $(TEST_TWO_FILE))"; \
-	else \
-		echo "$(TEST_TWO_FILE) already exists. Skipping download."; \
-	fi
+	@echo "Downloading $(TEST_TWO_FILE)..."
+	@$(CURL) $(FILE_TWO_URL) -o $(TEST_TWO_FILE).part
+	@mv $(TEST_TWO_FILE).part $(TEST_TWO_FILE)
+	@echo "Downloaded $(TEST_TWO_FILE)"
 
 clean:
-	rm -f $(TEST_FILE) $(TEST_TWO_FILE)
+	rm -f $(TEST_FILE) $(TEST_FILE).part $(TEST_TWO_FILE) $(TEST_TWO_FILE).part


### PR DESCRIPTION
CI has been red on every open PR across all platforms. Root cause is the fixture download, not the changes under review.

`pymkv-files.bnff.website` currently returns HTTP 521:

```
$ curl -sS -o /dev/null -w '%{http_code}\n' -L https://pymkv-files.bnff.website/file.mkv
521
```

`curl -sSL` without `--fail` writes the error body into `tests/file.mkv` and exits 0, so make treats the target as built. `mkvmerge -J` then exits 0 even for an unrecognized file, so the existing check passed as well — it only printed `"recognized": false` and moved on. Net effect: a 16-byte `error code: 521` file posing as an MKV, and ~80 test failures pointing at the wrong thing.

Changes:

- fixtures now come from `raw.githubusercontent.com/GitBib/pymkv-files`
- `curl --fail --retry 3` so HTTP errors abort the build
- download to `.part`, rename on success, so an interrupted download never leaves a partial file that make considers up to date
- assert `"recognized": true` for both fixtures before running pytest

Verified locally: download returns the expected 17344861 / 71216865 bytes with EBML magic `1a45dfa3`; a planted corrupt fixture now fails at the verify step instead of inside the suite; a 404 aborts with `curl: (56)` and leaves nothing behind. Full run: 679 passed, 2 skipped, mypy and ruff clean.

This needs to land before the open dependabot PRs (#118-#122) are rebased — otherwise they will keep failing for this reason rather than on their own merits.
