### PR TITLE
ci: pin uv, disable fail-fast, add job timeouts, drop dead conditions

### DIFF
--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 jobs:
   prek:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: j178/prek-action@v2.0.3

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   docs:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || !github.event.pull_request.draft
+    timeout-minutes: 15
     steps:
       - name: Check out repository
         uses: actions/checkout@v7.0.1
@@ -21,9 +21,10 @@ jobs:
         id: setup-uv
         uses: astral-sh/setup-uv@v9.0.0
         with:
-          version: latest
+          version: "0.12.1"
           python-version: "3.14"
           enable-cache: true
+          prune-cache: true
 
       - name: Install project
         run: uv sync --all-extras --dev
@@ -34,7 +35,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4.1.0
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch' }}
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -35,7 +35,9 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4.1.0
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch' }}
+        # Publish only from master. workflow_dispatch can be started on any
+        # branch, so gate on the ref rather than on the event.
+        if: ${{ github.ref == 'refs/heads/master' }}
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: github.event_name == 'release'
     steps:
     - name: Check out repository
@@ -29,9 +30,10 @@ jobs:
       id: setup-uv
       uses: astral-sh/setup-uv@v9.0.0
       with:
-        version: latest
+        version: "0.12.1"
         python-version: "3.14"
         enable-cache: true
+        prune-cache: true
 
     - name: Install project
       run: uv sync --all-extras --dev

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -18,10 +18,12 @@ permissions:
 jobs:
   run:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
       - name: Check out repository
         uses: actions/checkout@v7.0.1
@@ -64,9 +66,10 @@ jobs:
         id: setup-uv
         uses: astral-sh/setup-uv@v9.0.0
         with:
-          version: latest
+          version: "0.12.1"
           python-version: ${{ matrix.python-version }}
           enable-cache: true
+          prune-cache: true
 
       - name: Install project
         run: uv sync --all-extras --dev
@@ -77,7 +80,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6.0.0
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' || github.event_name == 'pull_request' }}
         with:
           env_vars: OS,PYTHON
           files: ./coverage.xml
@@ -94,7 +97,9 @@ jobs:
   runtime-import:
     name: Runtime-only import smoke test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
@@ -104,9 +109,10 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v9.0.0
         with:
-          version: latest
+          version: "0.12.1"
           python-version: ${{ matrix.python-version }}
           enable-cache: true
+          prune-cache: true
 
       - name: Import pymkv without dev dependencies
         run: uv run --no-dev python -c "import pymkv"


### PR DESCRIPTION
Follow-up to the setup-uv v9 bump in #121 plus a few things found while clearing the dependabot queue.

**`prune-cache: true`** — v9.0.0 flipped the `prune-cache` default from `true` to `false`, which is the release's only breaking change. `enable-cache: true` is set in all four workflows, so the change applies here: the uv cache stops being pruned and grows. With a 15-job matrix against a 10 GB per-repo cache limit and LRU eviction, that turns into cache thrash rather than a hard failure. This restores the old behaviour explicitly.

**`fail-fast: false`** — one failing job used to cancel the other 14. On #126 macOS 3.12 failed and everything else was cancelled, so there was no way to tell from the run whether the problem was platform-specific without digging into logs. Both matrices now report independently.

**Pinned uv to `0.12.1`** — `version: latest` meant a uv release could break CI with no change in the repo, and the failure would look like ours. The four call sites now agree on a version.

**`timeout-minutes` on every job** — there was none anywhere, so the default of 360 applied. A hung `choco install` would burn six hours of runner time.

**Dropped dead `if:` clauses:**

- `python-tests.yml` gated codecov on `workflow_dispatch`, which Tests never receives — it triggers on `push` to master and `pull_request` only.
- `python-docs.yml` gated deploy on `pull_request` and the job on `!github.event.pull_request.draft`, but Docs only triggers on `push` to master and `workflow_dispatch`. Reading it, you would think docs build on PRs. They do not.

Verified `prune-cache` exists as an input in setup-uv v9.0.0 (`default: "false"`) rather than assuming it from the changelog. All four workflow files parse, and every job now carries a timeout.

**Docs publish only from master** — the deploy step was gated on the event name, and `workflow_dispatch` can be started on any branch, so a manual Docs run from a feature branch would have published that branch's build to gh-pages. Now gated on `github.ref == 'refs/heads/master'`, which covers both push-to-master and a manual run on master. The build still runs on dispatch from any branch, it just does not publish.
