### PR TITLE
ci: make fixture download resumable and retry transient stalls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ tests/file.mkv
 tests/file-test.mkv
 tests/file_2.mkv
 .profiles
+
+# macOS
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,13 @@ TEST_TWO_FILE := tests/file_2.mkv
 
 TEST_DIR := tests/
 
-# --fail makes curl exit non-zero on HTTP errors instead of writing the error
-# body into the target file, which would leave a corrupt "MKV" behind.
-CURL := curl -sSL --fail --retry 3 --retry-delay 2
+# --fail exits non-zero on HTTP errors instead of writing the error body into the
+# target file, which would leave a corrupt "MKV" behind.
+# --retry alone does not cover a stall mid-transfer ("curl: (56) Recv failure"),
+# which is how a 71 MB download actually fails on a flaky runner, so
+# --retry-all-errors is needed. --continue-at - resumes into the same .part file
+# rather than restarting from zero on every attempt.
+CURL := curl -sSL --fail --retry 5 --retry-delay 2 --retry-all-errors --continue-at -
 
 .PHONY: test clean
 


### PR DESCRIPTION
Fixture download now resumes instead of restarting, and retries stalls that happen mid-transfer.

- `--retry-all-errors` — `--retry` alone does not cover a stall partway through a transfer
- `--continue-at -` — resume into the existing `.part`
- retries 3 → 5
- `.DS_Store` added to `.gitignore`
